### PR TITLE
feat: Support custom conversion between atomic name and DB value

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ User.can_make_admin?(confirmed_user)    # => true
 admin = User.make_admin(confirmed_user)
 
 # Store changeset to the database
-Repo.update(admin)                      
+Repo.update(admin)
 
 
 # List all possible states
@@ -98,6 +98,43 @@ end
 ```
 
 Now your state will be stored into `rules` column.
+
+### Custom mapping between state name and field value
+
+By default, the atomic state names are stringified when generating the changeset. However, there are situations where the underlying Ecto schema value isn't simply a stringified version of the state name. You can customize the mapping by passing cast/load functions like so:
+
+```elixir
+defmodule Dummy.WritingStyle do
+  use Dummy.Web, :model
+
+  use EctoStateMachine,
+    states: [:upcased, :camel_cased],
+    cast_fn: fn
+      :upcased -> "UPCASED"
+      :camel_cased -> "camelCased"
+    end,
+    load_fn: fn
+      "UPCASED" -> :upcased
+      "camelCased" -> :camel_cased
+    end,
+    events: [
+      [
+        name: :upcase,
+        from: [:camel_cased],
+        to: :upcased
+      ],
+      [
+        name: :camel_case,
+        from: [:upcased],
+        to: :camel_cased
+      ]
+    ]
+
+  schema "writing_styles" do
+    field :state, :string
+  end
+end
+```
 
 ## Contributions
 

--- a/priv/test/dummy/repo/migrations/20180511030316_create_writing_style.exs
+++ b/priv/test/dummy/repo/migrations/20180511030316_create_writing_style.exs
@@ -1,0 +1,9 @@
+defmodule Dummy.Repo.Migrations.CreateWritingStyle do
+  use Ecto.Migration
+
+  def change do
+    create table(:writing_styles) do
+      add :state, :string
+    end
+  end
+end

--- a/test/dummy/factories.ex
+++ b/test/dummy/factories.ex
@@ -6,4 +6,10 @@ defmodule Dummy.Factories do
       rules: "started"
     }
   end
+
+  def writing_style_factory do
+    %Dummy.WritingStyle{
+      state: nil
+    }
+  end
 end

--- a/test/dummy/web/models/writing_style.ex
+++ b/test/dummy/web/models/writing_style.ex
@@ -1,0 +1,30 @@
+defmodule Dummy.WritingStyle do
+  use Dummy.Web, :model
+
+  use EctoStateMachine,
+    states: [:upcased, :camel_cased],
+    cast_fn: fn
+      :upcased -> "UPCASED"
+      :camel_cased -> "camelCased"
+    end,
+    load_fn: fn
+      "UPCASED" -> :upcased
+      "camelCased" -> :camel_cased
+    end,
+    events: [
+      [
+        name: :upcase,
+        from: [:camel_cased],
+        to: :upcased
+      ],
+      [
+        name: :camel_case,
+        from: [:upcased],
+        to: :camel_cased
+      ]
+    ]
+
+  schema "writing_styles" do
+    field :state, :string
+  end
+end

--- a/test/ecto_state_machine_test.exs
+++ b/test/ecto_state_machine_test.exs
@@ -2,20 +2,21 @@ defmodule EctoStateMachineTest do
   use ExUnit.Case, async: true
 
   alias Dummy.User
+  alias Dummy.WritingStyle
 
   import Dummy.Factories
 
-  setup_all do
-    {
-      :ok,
-      unconfirmed_user: insert(:user, %{ rules: "unconfirmed" }),
-      confirmed_user:   insert(:user, %{ rules: "confirmed" }),
-      blocked_user:     insert(:user, %{ rules: "blocked" }),
-      admin:            insert(:user, %{ rules: "admin" })
-    }
-  end
+  describe "User" do
+    setup do
+      {
+        :ok,
+        unconfirmed_user: insert(:user, %{ rules: "unconfirmed" }),
+        confirmed_user:   insert(:user, %{ rules: "confirmed" }),
+        blocked_user:     insert(:user, %{ rules: "blocked" }),
+        admin:            insert(:user, %{ rules: "admin" })
+      }
+    end
 
-  describe "events" do
     test "#confirm", context do
       changeset = User.confirm(context[:unconfirmed_user])
       assert changeset.valid?            == true
@@ -70,9 +71,7 @@ defmodule EctoStateMachineTest do
       assert changeset.valid? == false
       assert changeset.errors == [rules: {"You can't move state from :admin to :admin", []}]
     end
-  end
 
-  describe "can_?" do
     test "#can_confirm?", context do
       assert User.can_confirm?(context[:unconfirmed_user])    == true
       assert User.can_confirm?(context[:confirmed_user])      == false
@@ -93,13 +92,60 @@ defmodule EctoStateMachineTest do
       assert User.can_make_admin?(context[:blocked_user])     == false
       assert User.can_make_admin?(context[:admin])            == false
     end
+
+    test "#states" do
+      assert User.rules_states == [:unconfirmed, :confirmed, :blocked, :admin]
+    end
+
+    test "#events" do
+      assert User.rules_events == [:confirm, :block, :make_admin]
+    end
   end
 
-  test "#states" do
-    assert User.rules_states == [:unconfirmed, :confirmed, :blocked, :admin]
-  end
+  describe "WritingStyle" do
+    setup do
+      [
+        upcased: insert(:writing_style, state: "UPCASED"),
+        camel_cased: insert(:writing_style, state: "camelCased")
+      ]
+    end
 
-  test "#events" do
-    assert User.rules_events == [:confirm, :block, :make_admin]
+    test "upcase/1", %{upcased: upcased, camel_cased: camel_cased} do
+      changeset = WritingStyle.upcase(camel_cased)
+      assert changeset.valid? == true
+      assert changeset.changes.state == "UPCASED"
+
+      changeset = WritingStyle.upcase(upcased)
+      assert changeset.valid? == false
+      assert changeset.errors == [state: {"You can't move state from :upcased to :upcased", []}]
+    end
+
+    test "camel_case/1", %{upcased: upcased, camel_cased: camel_cased} do
+      changeset = WritingStyle.camel_case(camel_cased)
+      assert changeset.valid? == false
+      assert changeset.errors == [state: {"You can't move state from :camel_cased to :camel_cased", []}]
+
+      changeset = WritingStyle.camel_case(upcased)
+      assert changeset.valid? == true
+      assert changeset.changes.state == "camelCased"
+    end
+
+    test "can_upcase?/1", %{upcased: upcased, camel_cased: camel_cased} do
+      assert WritingStyle.can_upcase?(camel_cased) == true
+      assert WritingStyle.can_upcase?(upcased) == false
+    end
+
+    test "can_camel_case?/1", %{upcased: upcased, camel_cased: camel_cased} do
+      assert WritingStyle.can_camel_case?(camel_cased) == false
+      assert WritingStyle.can_camel_case?(upcased) == true
+    end
+
+    test "states" do
+      assert WritingStyle.states == [:upcased, :camel_cased]
+    end
+
+    test "events" do
+      assert WritingStyle.events == [:upcase, :camel_case]
+    end
   end
 end


### PR DESCRIPTION
Allow custom mapping between the atomic state names and their corresponding database values.